### PR TITLE
Removed urn:ietf:wg:oauth:2.0:oob redirect URL

### DIFF
--- a/demo/GraphTutorial/auth/AuthManager.ts
+++ b/demo/GraphTutorial/auth/AuthManager.ts
@@ -11,7 +11,7 @@ import { AuthConfig } from './AuthConfig';
 
 const config: AuthConfiguration = {
   clientId: AuthConfig.appId,
-  redirectUrl: Platform.OS === 'ios' ? 'urn:ietf:wg:oauth:2.0:oob' : 'graph-tutorial://react-native-auth',
+  redirectUrl: 'graph-tutorial://react-native-auth/',
   scopes: AuthConfig.appScopes,
   additionalParameters: { prompt: 'select_account' },
   serviceConfiguration: {
@@ -24,6 +24,8 @@ export class AuthManager {
 
   static signInAsync = async () => {
     const result = await authorize(config);
+
+    console.log(result.accessToken);
 
     // Store the access token, refresh token, and expiration time in storage
     await AsyncStorage.setItem('userToken', result.accessToken);

--- a/tutorial/03-register-app.md
+++ b/tutorial/03-register-app.md
@@ -19,7 +19,3 @@ In this exercise you will create a new Azure AD native application using the Azu
 1. Select **Register**. On the **React Native Graph Tutorial** page, copy the value of the **Application (client) ID** and save it, you will need it in the next step.
 
     ![A screenshot of the application ID of the new app registration](./images/aad-application-id.png)
-
-1. Under **Manage**, select **Authentication**. On the **Redirect URIs** page, add another redirect URI of type **Public client (mobile & desktop)**, with the URI `urn:ietf:wg:oauth:2.0:oob`. Select **Save**.
-
-    ![A screenshot of the Redirect URIs page](./images/aad-redirect-uris.png)


### PR DESCRIPTION
This used to be required for iOS to work, now it causes sign in to fail.

Fixes #16